### PR TITLE
Fix common msm8916  folder

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -31,7 +31,7 @@ TARGET_SCREEN_HEIGHT := 1280
 TARGET_SCREEN_WIDTH := 720
 
 # Inherit from msm8916-common
-$(call inherit-product, device/asus/msm8916-common/msm8916.mk)
+$(call inherit-product, device/asus/qcom/common/msm8916.mk)
 
 PRODUCT_PACKAGES += \
     init.target.rc


### PR DESCRIPTION
Please merge this request to avoid build error or rename the device_asus_qcom_common to device_asus_msm8916